### PR TITLE
Java: fix UnreachabaleBasicBlock

### DIFF
--- a/java/ql/lib/semmle/code/java/controlflow/UnreachableBlocks.qll
+++ b/java/ql/lib/semmle/code/java/controlflow/UnreachableBlocks.qll
@@ -207,14 +207,12 @@ class UnreachableBasicBlock extends BasicBlock {
       conditionBlock.controls(this, constant.booleanNot())
     )
     or
-    // This block is not reachable in the CFG, and is not a callable, a body of a callable, an
-    // expression in an annotation, an expression in an assert statement, or a catch clause.
+    // This block is not reachable in the CFG, and is not the entrypoint in a callable, an
+    // expression in an assert statement, or a catch clause.
     forall(BasicBlock bb | bb = this.getABBPredecessor() | bb instanceof UnreachableBasicBlock) and
-    not exists(Callable c | c.getBody() = this) and
-    not this instanceof Callable and
-    not exists(Annotation a | a.getAChildExpr*() = this) and
-    not this.(Expr).getEnclosingStmt() instanceof AssertStmt and
-    not this instanceof CatchClause
+    not exists(Callable c | c.getBody().getControlFlowNode() = this.getFirstNode()) and
+    not exists(AssertStmt a | a = this.getFirstNode().asExpr().getEnclosingStmt()) and
+    not this.getFirstNode().asStmt() instanceof CatchClause
     or
     // Switch statements with a constant comparison expression may have unreachable cases.
     exists(ConstSwitchStmt constSwitchStmt, BasicBlock failingCaseBlock |
@@ -223,7 +221,7 @@ class UnreachableBasicBlock extends BasicBlock {
       // Not accessible from the successful case
       not constSwitchStmt.getMatchingCase().getBasicBlock().getABBSuccessor*() = failingCaseBlock and
       // Blocks dominated by the failing case block are unreachable
-      constSwitchStmt.getAFailingCase().getBasicBlock().bbDominates(this)
+      failingCaseBlock.bbDominates(this)
     )
   }
 }


### PR DESCRIPTION
Fix is taken from https://github.com/github/codeql/pull/711/files#diff-24d21bcfe63e29a6ef28151d9bd8eeaa610565c3ed7b846de1eb5fb0be661ae5 It is not clear why anotations are left out.